### PR TITLE
GH-27 : Added sonar cloud coverage badge with percentage in ReadMe file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build](https://github.com/abhishekmalvadkar/lms-service-api/actions/workflows/Dev-CI.yml/badge.svg)](https://github.com/abhishekmalvadkar/lms-service-api/actions/workflows/Dev-CI.yml)
 [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=abhishekmalvadkar_lms-service-api&metric=alert_status)](https://sonarcloud.io/dashboard?id=abhishekmalvadkar_lms-service-api)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=abhishekmalvadkar_lms-service-api&metric=coverage)](https://sonarcloud.io/project/overview?id=abhishekmalvadkar_lms-service-api)
 
 
 


### PR DESCRIPTION
Here we have achieved below things : 

* Added sonar cloud coverage badge with percentage in ReadMe file
* So any one can see live code coverage percentage for LMS API container and click on it to see detailed info on sonar cloud 